### PR TITLE
Stop the announcement from being read out on initial page load

### DIFF
--- a/addon/instance-initializers/scroll-on-click.js
+++ b/addon/instance-initializers/scroll-on-click.js
@@ -5,14 +5,6 @@ export function initialize(appInstance) {
 
     router.on('routeWillChange', scroll.routeWillChange);
     router.on('routeDidChange', scroll.routeDidChange);
-
-    const element = document.createElement('div');
-    const text = document.createTextNode('The page navigation is complete. You may now navigate the page content as you wish.');
-    element.append(text);
-    element.setAttribute('id', scroll.guid);
-    element.setAttribute('class', 'ember-scroll-on-click-navigation-message');
-    element.setAttribute('tabindex', -1);
-    document.body.prepend(element);
   }
 }
 

--- a/addon/services/scroll.js
+++ b/addon/services/scroll.js
@@ -69,6 +69,7 @@ export default class ScrollService extends Service {
     element.setAttribute('id', this.guid);
     element.setAttribute('class', 'ember-scroll-on-click-navigation-message');
     element.setAttribute('tabindex', -1);
+    element.setAttribute('role', 'text');
     document.body.prepend(element);
 
     this._hasSetupElement = true;

--- a/addon/services/scroll.js
+++ b/addon/services/scroll.js
@@ -11,6 +11,8 @@ export default class ScrollService extends Service {
   doScroll = true;
   @tracked isLoading = false;
 
+  _hasSetupElement = false;
+
   constructor() {
     super(...arguments);
 
@@ -48,10 +50,27 @@ export default class ScrollService extends Service {
   @action
   scrollUp() {
     if (this.doScroll) {
+      this._setupElement();
       document.getElementById(this.guid).focus();
     }
 
     this.doScroll = true;
     this.isLoading = false;
+  }
+
+  _setupElement() {
+    if(this._hasSetupElement) {
+      return;
+    }
+
+    const element = document.createElement('div');
+    const text = document.createTextNode('The page navigation is complete. You may now navigate the page content as you wish.');
+    element.append(text);
+    element.setAttribute('id', this.guid);
+    element.setAttribute('class', 'ember-scroll-on-click-navigation-message');
+    element.setAttribute('tabindex', -1);
+    document.body.prepend(element);
+
+    this._hasSetupElement = true;
   }
 }


### PR DESCRIPTION
As we were adding the div with the scroll announcement to the DOM regardless of if we have navigated, it was still being read out on the initial page load if you were using a screen reader. 

This PR also makes the announcer div use `role="text"` so the screen reader does not read the announcement as "an empty group"