### PR TITLE
WIP: add (optional) ember-intl support

### DIFF
--- a/addon/services/scroll.js
+++ b/addon/services/scroll.js
@@ -3,9 +3,11 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { scheduleOnce, next } from '@ember/runloop';
 import { guidFor } from '@ember/object/internals';
+import { getOwner } from '@ember/application';
 
 export default class ScrollService extends Service {
   @service router;
+  intl = getOwner(this).lookup('service:intl');
 
   guid = `${guidFor(this)}-scroll-on-click-target`;
   doScroll = true;
@@ -63,8 +65,13 @@ export default class ScrollService extends Service {
       return;
     }
 
+    let navigationMessage = 'The page navigation is complete. You may now navigate the page content as you wish.';
+    if (this.intl && this.intl.exists('emberScroll.navigationMessage')) {
+      navigationMessage = this.intl.t('emberScroll.navigationMessage');
+    }
+
     const element = document.createElement('div');
-    const text = document.createTextNode('The page navigation is complete. You may now navigate the page content as you wish.');
+    const text = document.createTextNode(navigationMessage);
     element.append(text);
     element.setAttribute('id', this.guid);
     element.setAttribute('class', 'ember-scroll-on-click-navigation-message');


### PR DESCRIPTION
This adds optional support for ember-intl. If the service is found we will use the translation key `emberScroll.navigationMessage`. If the key is not found we fallback to the default message.

TODO:
- [ ] add tests when #6 has been merged