### PR TITLE
prepend to rootElement instead of body when configured

### DIFF
--- a/addon/services/scroll.js
+++ b/addon/services/scroll.js
@@ -77,4 +77,13 @@ export default class ScrollService extends Service {
 
     this._hasSetupElement = true;
   }
+
+  willDestroy() {
+    const element = document.getElementById(this.guid);
+    if (element) {
+      element.remove();
+    }
+
+    super.willDestroy();
+  }
 }

--- a/addon/services/scroll.js
+++ b/addon/services/scroll.js
@@ -2,6 +2,7 @@ import Service, { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { scheduleOnce, next } from '@ember/runloop';
 import { guidFor } from '@ember/object/internals';
+import { getOwner } from '@ember/application';
 
 export default class ScrollService extends Service {
   @service router;
@@ -65,7 +66,14 @@ export default class ScrollService extends Service {
     element.setAttribute('class', 'ember-scroll-navigation-message');
     element.setAttribute('tabindex', -1);
     element.setAttribute('role', 'text');
-    document.body.prepend(element);
+
+    const config = getOwner(this).resolveRegistration('config:environment');
+
+    // attach to the body unless a rootElement is configured for the app
+    const rootElement = config.APP.rootElement
+      ? document.querySelector(config.APP.rootElement)
+      : document.body;
+    rootElement.prepend(element);
 
     this._hasSetupElement = true;
   }

--- a/tests/acceptance/scroll-test.js
+++ b/tests/acceptance/scroll-test.js
@@ -17,8 +17,8 @@ module('Acceptance | scroll', function(hooks) {
 
     assert.dom('.ember-scroll-navigation-message', document).exists();
 
-    // check if we're the first element in the body
-    assert.dom('body > *:first-child', document).hasClass('ember-scroll-navigation-message');
+    // check if we're the first element in the rootElement
+    assert.dom('#ember-testing > *:first-child', document).hasClass('ember-scroll-navigation-message');
 
     assert.dom('.ember-scroll-navigation-message', document).isFocused();
     assert.dom('.ember-scroll-navigation-message', document).hasText('The page navigation is complete. You may now navigate the page content as you wish.');


### PR DESCRIPTION
This makes ember-scroll prepend its navigation message div/scroll target to [the configured rootElement ](https://guides.emberjs.com/release/configuring-ember/embedding-applications/#toc_changing-the-root-element) with a fallback to the `body`.

It also makes sure the element is cleaned up when the scroll service is destroyed (especially relevant for tests).