### PR TITLE
also use scrollTo(0,0) to fix safari not scrolling

### DIFF
--- a/addon/services/scroll.js
+++ b/addon/services/scroll.js
@@ -51,6 +51,7 @@ export default class ScrollService extends Service {
     if (this.doScroll) {
       this._setupElement();
       document.getElementById(this.guid).focus();
+      window.scrollTo(0, 0);
     }
 
     this.doScroll = true;


### PR DESCRIPTION
@nickschot noticed that the scroll behaviour was a bit off in safari. It turns out that there seems to be some sort of timing issue only in safari where 8/10 times it won't scroll effectively. The timing issue is so small that you didn't see it when running in development mode but it did show up in production on netlify previews